### PR TITLE
chore: add type hint to not inferred model property

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import base64
 import collections
 import hashlib

--- a/juju/model.py
+++ b/juju/model.py
@@ -15,6 +15,7 @@ from concurrent.futures import CancelledError
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 import websockets
@@ -39,6 +40,13 @@ from .placement import parse as parse_placement
 from .tag import application as application_tag
 from .url import URL, Schema
 from .version import DEFAULT_ARCHITECTURE
+
+if TYPE_CHECKING:
+    from .application import Application
+    from .client import _definitions
+    from .machine import Machine
+    from .relation import Relation
+    from .unit import Unit
 
 log = logging.getLogger(__name__)
 
@@ -131,7 +139,7 @@ class ModelState:
         }
 
     @property
-    def applications(self):
+    def applications(self) -> dict[str, Application]:
         """Return a map of application-name:Application for all applications
         currently in the model.
 
@@ -139,7 +147,7 @@ class ModelState:
         return self._live_entity_map('application')
 
     @property
-    def remote_applications(self):
+    def remote_applications(self) -> dict[str, Application]:
         """Return a map of application-name:Application for all remote
         applications currently in the model.
 
@@ -147,14 +155,14 @@ class ModelState:
         return self._live_entity_map('remoteApplication')
 
     @property
-    def application_offers(self):
+    def application_offers(self) -> dict[str, Application]:
         """Return a map of application-name:Application for all applications
         offers currently in the model.
         """
         return self._live_entity_map('applicationOffer')
 
     @property
-    def machines(self):
+    def machines(self) -> dict[str, Machine]:
         """Return a map of machine-id:Machine for all machines currently in
         the model.
 
@@ -162,7 +170,7 @@ class ModelState:
         return self._live_entity_map('machine')
 
     @property
-    def units(self):
+    def units(self) -> dict[str, Unit]:
         """Return a map of unit-id:Unit for all units currently in
         the model.
 
@@ -170,7 +178,7 @@ class ModelState:
         return self._live_entity_map('unit')
 
     @property
-    def relations(self):
+    def relations(self) -> dict[str, Relation]:
         """Return a map of relation-id:Relation for all relations currently in
         the model.
 
@@ -1060,7 +1068,7 @@ class Model:
         return self._charmhub
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of this model
 
         """
@@ -1069,7 +1077,7 @@ class Model:
         return self._info.name
 
     @property
-    def info(self):
+    def info(self) -> None | _definitions.ModelInfo:
         """Return the cached client.ModelInfo object for this Model.
 
         If Model.get_info() has not been called, this will return None.


### PR DESCRIPTION
#### Description

This PR adds type hints to model properties that cannot currently be inferred automatically. Dynamically typed client modules are omitted.


#### QA Steps

```
tox -e lint
```

All CI tests need to pass.

There isn't much of a change, just addition of type hinting to enhance developer experience :) Thank you